### PR TITLE
Assets path reading fixed, npc stopping after 1 round fixed.

### DIFF
--- a/src/AutomatedCar/Models/World.cs
+++ b/src/AutomatedCar/Models/World.cs
@@ -157,7 +157,7 @@
             string exeDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
 
 
-            string fullPath = Path.GetFullPath(Path.Combine(exeDirectory, @"..\..\..\..", "AutomatedCar", "Assets"));
+            string fullPath = Path.GetFullPath(Path.Combine(exeDirectory, @"../../../..", "AutomatedCar", "Assets"));
 
             foreach (var file in Directory.GetFiles(fullPath))
             {

--- a/src/AutomatedCar/Models/World.cs
+++ b/src/AutomatedCar/Models/World.cs
@@ -13,6 +13,7 @@
     using Avalonia.Media;
 
     using System.Reflection;
+    using System.Linq;
 
     public class World
     {
@@ -161,7 +162,7 @@
             foreach (var file in Directory.GetFiles(fullPath))
             {
                 
-                if (file.Contains("_route"))
+                if (file.Contains(filename.Split('.')[2] + "_route"))
                 {
                    
                     string json = File.ReadAllText(file);

--- a/src/AutomatedCar/Models/World.cs
+++ b/src/AutomatedCar/Models/World.cs
@@ -12,6 +12,8 @@
     using Visualization;
     using Avalonia.Media;
 
+    using System.Reflection;
+
     public class World
     {
         private int controlledCarPointer = 0;
@@ -148,25 +150,39 @@
             LoadNPCsFromJSON(filename);
         }
 
+
         private void LoadNPCsFromJSON(string filename)
         {
-            string assethPath = Path.GetFullPath(Path.Combine(Directory.GetParent(Directory.GetCurrentDirectory()).Parent.FullName, @"src/AutomatedCar/Assets"));
+            string exeDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
 
-            foreach (var file in Directory.GetFiles(assethPath))
+
+            string fullPath = Path.GetFullPath(Path.Combine(exeDirectory, @"..\..\..\..", "AutomatedCar", "Assets"));
+
+            foreach (var file in Directory.GetFiles(fullPath))
             {
-                if (file.Contains(filename.Split('.')[2] + "_route"))
+                
+                if (file.Contains("_route"))
                 {
+                   
                     string json = File.ReadAllText(file);
+                   
                     var route = JsonConvert.DeserializeObject<Route>(json);
+                    
                     NPCRoutes.Add(route);
+                    
                     var npc = new NPCCar(route.RoutePoints[route.StartPointID].X, route.RoutePoints[route.StartPointID].Y, route.ObjectFileName, route);
 
                     AddObject(npc);
                     npc.Start();
-
                 }
             }
         }
+
+
+
+
+
+
 
         private List<System.Drawing.PointF> ToDotNetPoints(IList<Avalonia.Point> points)
         {

--- a/src/AutomatedCar/SystemComponents/NPCMovingComponent.cs
+++ b/src/AutomatedCar/SystemComponents/NPCMovingComponent.cs
@@ -150,6 +150,10 @@
                 {
                     car.Route.CurrentPointID = car.Route.RoutePoints.IndexOf(car.Route.RoutePoints.Single(t => t == next));
                 }
+                else if (car.Route.RoutePoints[car.Route.CurrentPointID + 1] == car.Route.RoutePoints.Last() && car.Route.RepeatAfterFinish)
+                {
+                    car.Route.CurrentPointID = car.Route.RoutePoints.IndexOf(car.Route.RoutePoints.Single(t => t == next));
+                }
                 
                 if (car.Route.RoutePoints[car.Route.CurrentPointID+1] == car.Route.RoutePoints.Last() && car.Route.RepeatAfterFinish)
                 {


### PR DESCRIPTION
Most az útvonal beolvasásakor futási időben keresi meg a .exe helyét, és ez alapján keresi az assets mappát, légyszi @Siposattila checkold le, hogy nálad működik-e.