### PR TITLE
Hotfix 84 fölösleges systemcomponent ek regisztrálásának kiszűrése

### DIFF
--- a/src/AutomatedCar/Models/AutomatedCar.cs
+++ b/src/AutomatedCar/Models/AutomatedCar.cs
@@ -20,10 +20,14 @@ namespace AutomatedCar.Models
             this.ZIndex = 10;
             CarTransmissionL = Transmissions.X;
             CarTransmissionR = Transmissions.R;
-            new ControlledCarSensor(virtualFunctionBus);
-            this.camera = new Camera(this.virtualFunctionBus);
-            this.collision = new Collision(this.virtualFunctionBus);
-            this.radar = new Radar(this.virtualFunctionBus);
+            if (this is UserControlledCar)
+            {
+                new ControlledCarSensor(virtualFunctionBus);
+                this.camera = new Camera(this.virtualFunctionBus);
+                this.collision = new Collision(this.virtualFunctionBus);
+                this.radar = new Radar(this.virtualFunctionBus);
+            }
+            
         }
 
         

--- a/src/AutomatedCar/SystemComponents/ControlledCarSensor.cs
+++ b/src/AutomatedCar/SystemComponents/ControlledCarSensor.cs
@@ -17,7 +17,7 @@
             //this.controlledCar = controlledCar;
             this.CarPacket = new ControlledCarPacket();
             base.virtualFunctionBus.ControlledCarPacket = CarPacket;
-            this.virtualFunctionBus.RegisterComponent(this);
+            //this.virtualFunctionBus.RegisterComponent(this);
         }
 
         public override void Process()

--- a/src/AutomatedCar/SystemComponents/Engine.cs
+++ b/src/AutomatedCar/SystemComponents/Engine.cs
@@ -17,7 +17,7 @@
         public Engine(VirtualFunctionBus virtualFunctionBus,AutomatedCar automatedCar) : base(virtualFunctionBus)
         {
             this.virtualFunctionBus = virtualFunctionBus;
-            virtualFunctionBus.RegisterComponent(this);
+            //virtualFunctionBus.RegisterComponent(this);
             this.automatedCar = automatedCar;
         }
 

--- a/src/AutomatedCar/SystemComponents/Sensors/Camera.cs
+++ b/src/AutomatedCar/SystemComponents/Sensors/Camera.cs
@@ -13,7 +13,7 @@ namespace AutomatedCar.SystemComponents.Sensors
         {
             this.sensorPacket = new CameraPacket();
             virtualFunctionBus.CameraPacket = (IReadOnlyCameraPacket)this.sensorPacket;
-            virtualFunctionBus.RegisterComponent(this);
+            //virtualFunctionBus.RegisterComponent(this);
             Console.WriteLine("Camera is on!");
         }
 

--- a/src/AutomatedCar/SystemComponents/Sensors/Collision.cs
+++ b/src/AutomatedCar/SystemComponents/Sensors/Collision.cs
@@ -15,7 +15,7 @@ namespace AutomatedCar.SystemComponents.Sensors
         {
             this.sensorPacket = new CollisionPacket();
             this.virtualFunctionBus.CollisionPacket = (IReadOnlyCollisionPacket)this.sensorPacket;
-            virtualFunctionBus.RegisterComponent(this);
+            //virtualFunctionBus.RegisterComponent(this);
             Console.WriteLine("Collision is on!");
         }
 

--- a/src/AutomatedCar/SystemComponents/Sensors/Radar.cs
+++ b/src/AutomatedCar/SystemComponents/Sensors/Radar.cs
@@ -12,7 +12,7 @@ namespace AutomatedCar.SystemComponents.Sensors
         {
             this.sensorPacket = new RadarPacket();
             this.virtualFunctionBus.RadarPacket = (IReadOnlySensorPacket)this.sensorPacket;
-            virtualFunctionBus.RegisterComponent(this);
+            //virtualFunctionBus.RegisterComponent(this);
             Console.WriteLine("Radar is on!");
         }
 


### PR DESCRIPTION
A SystemComponent konstruktora meghívja a RegisterComponent metódust, így minden egyes külön meghíváskor duplán voltak regisztrálva a komponensek.